### PR TITLE
feat: card helper utilities in card service

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -27,7 +27,11 @@ export class AppComponent {
 
     /**
      * Update app filters state with filter event.
+     * Note, it's important that the filters are always a new object;
+     * Allows a new, random hand to be drawn with identical filters.
      */
-    this.filters.next($event);
+    this.filters.next({
+      ...$event
+    });
   }
 }

--- a/src/app/filters/filters.component.html
+++ b/src/app/filters/filters.component.html
@@ -16,7 +16,7 @@
   </mat-form-field>
 
   <strong>
-    Max card value: {{this.formatFaceLabel(selectedFilters.maxCardValue)}}
+    Max card value: {{this.playingCardsService.mapIndexToCardValue(selectedFilters.maxCardValue)}}
   </strong>
   <mat-slider
     [(ngModel)]="selectedFilters.maxCardValue"
@@ -26,12 +26,12 @@
     max="12"
     step="1"
     value="1"
-    [displayWith]="formatFaceLabel"
+    [displayWith]="playingCardsService.mapIndexToCardValueShort"
     (change)="updateFilterSelections($event)"
   ></mat-slider>
 
   <strong>
-    Min card value: {{this.formatFaceLabel(selectedFilters.minCardValue)}}
+    Min card value: {{this.playingCardsService.mapIndexToCardValue(selectedFilters.minCardValue)}}
   </strong>
   <mat-slider
     [(ngModel)]="selectedFilters.minCardValue"
@@ -41,7 +41,7 @@
     max="12"
     step="1"
     value="1"
-    [displayWith]="formatFaceLabel"
+    [displayWith]="playingCardsService.mapIndexToCardValueShort"
     (change)="updateFilterSelections($event)"
   ></mat-slider>
 

--- a/src/app/filters/filters.component.ts
+++ b/src/app/filters/filters.component.ts
@@ -1,6 +1,8 @@
 import { Component, OnInit, Output, EventEmitter, ChangeDetectionStrategy } from '@angular/core';
 import { Filters } from '../filters';
 
+import { PlayingCardsService } from '../playing-cards.service';
+
 @Component({
   selector: 'app-filters',
   templateUrl: './filters.component.html',
@@ -18,7 +20,7 @@ export class FiltersComponent implements OnInit {
 
   error: string | null;
 
-  constructor() { }
+  constructor(public playingCardsService: PlayingCardsService) { }
 
   ngOnInit() {
   }
@@ -35,55 +37,6 @@ export class FiltersComponent implements OnInit {
     if (this.filtersSatisfiable(this.selectedFilters)) {
       this.filterEvent.emit(this.selectedFilters);
     }
-  }
-
-  /**
-   * Translate a card's deck index to a face value.
-   * @param index Index of card selected from 1 or more decks.
-   */
-  formatFaceLabel(index: number | null) {
-    /**
-     * Disregard suit, only need face value.
-     */
-    const noSuit = index % 13;
-
-    /**
-     * Card face value label to return.
-     */
-    let label;
-    if (noSuit >= 0 && noSuit < 9) {
-      /**
-       * Indices from 0 to 8 are just incremented by 2.
-       * Face values 2 through 9.
-       */
-      label = '' + (noSuit + 2);
-    } else {
-      /**
-       * Indices from 9 to 12 are face cards.
-       * Face values Jack through Ace.
-       */
-      switch (noSuit) {
-        case 9:
-          label = 'J';
-          break;
-        case 10:
-          label = 'Q';
-          break;
-        case 11:
-          label = 'K';
-          break;
-        case 12:
-          label = 'A';
-          break;
-
-        // This shouldn't ever happen.
-        default:
-          label = '';
-          break;
-      }
-    }
-
-    return label;
   }
 
   /**

--- a/src/app/hand/hand.component.ts
+++ b/src/app/hand/hand.component.ts
@@ -6,6 +6,8 @@ import {
 import { Hand } from '../hand';
 import { Filters } from '../filters';
 
+import { PlayingCardsService } from '../playing-cards.service';
+
 @Component({
   selector: 'app-hand',
   templateUrl: './hand.component.html',
@@ -13,6 +15,8 @@ import { Filters } from '../filters';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class HandComponent {
+
+  constructor(private playingCardsService: PlayingCardsService) { }
 
   /**
    * Selected filters constraints for generating hand.
@@ -59,7 +63,7 @@ export class HandComponent {
       const randomCard = handCandidates[randomIndex];
 
       // Translate random deck index to suit and value
-      const suit = this.mapIntToSuit(randomCard);
+      const suit = this.playingCardsService.mapIndexToCardSuit(randomCard);
       const value = randomCard % 13;
 
       // Add to hand if candidate passes filter criteria
@@ -70,7 +74,7 @@ export class HandComponent {
         // Push card indices and card objects separately.
         hand.push({
           suit,
-          value: this.mapIntToCardValue(randomCard)
+          value: this.playingCardsService.mapIndexToCardValue(randomCard),
         });
       }
 
@@ -86,79 +90,4 @@ export class HandComponent {
     return hand;
   }
 
-  /**
-   * Translate a card's deck index to a suit.
-   * @param index Integer corresponding to a specific card in a collection of 1 or more standard playing card decks.
-   * [TODO] deduplicate int-to-suit and int-to-face-value functionality here and in `filters.component.ts`.
-   */
-  mapIntToSuit(index: number) {
-    /**
-     * Normalize index if drawing from multiple decks.
-     * e.g. 2 decks will have 2 entire sets of Spades:
-     * 2 Aces of Spades, index 12 and 64
-     *   12 % 52 = 12
-     *   64 % 52 = 12
-     */
-    const normalizedIndex = index % 52;
-
-    if (normalizedIndex >= 0 && normalizedIndex < 13) {
-      return 'spade';
-    } else if (normalizedIndex >= 13 && normalizedIndex < 26) {
-      return 'heart';
-    } else if (normalizedIndex >= 26 && normalizedIndex < 39) {
-      return 'club';
-    } else {
-      return 'diamond';
-    }
-  }
-
-  /**
-   * Translate a card's deck index to a face value.
-   * @param index Integer corresponding to a specific card in a collection of 1 or more standard playing card decks.
-   */
-  mapIntToCardValue(index: number) {
-    /**
-     * We don't need to normalize the index for card face value.
-     * Face values are always the same within suit boundaries.
-     * No matter how many decks we pull from, face value will always be index modulo 13.
-     */
-    const noSuit = index % 13;
-
-    let value;
-    if (noSuit >= 0 && noSuit < 9) {
-      /**
-       * Indices from 0 to 8 are just incremented by 2.
-       * Face values 2 through 9.
-       */
-      value = '' + (noSuit + 2);
-
-    } else {
-      /**
-       * Indices from 9 to 12 are face cards.
-       * Face values Jack through Ace.
-       */
-      switch (noSuit) {
-        case 9:
-          value = 'jack';
-          break;
-        case 10:
-          value = 'queen';
-          break;
-        case 11:
-          value = 'king';
-          break;
-        case 12:
-          value = 'ace';
-          break;
-
-        // This shouldn't ever happen.
-        default:
-          value = null;
-          break;
-      }
-
-    }
-
-    return value;
-  }
 }

--- a/src/app/playing-cards.service.spec.ts
+++ b/src/app/playing-cards.service.spec.ts
@@ -2,11 +2,190 @@ import { TestBed } from '@angular/core/testing';
 
 import { PlayingCardsService } from './playing-cards.service';
 
+/**
+ * Range of concatenated playing card decks to test against.
+ */
+const DECKS_TO_TEST = 10;
+
+/**
+ * Number of playing cards in a standard deck.
+ */
+const DECK_SIZE = 52;
+
+/**
+ * Number of playing cards per suit.
+ */
+const SUIT_SIZE = 13;
+
+/**
+ * Possible suit values.
+ */
+enum DECK_SUITS {
+  spade,
+  heart,
+  club,
+  diamond,
+};
+
+/**
+ * Possible face values.
+ */
+const SUIT_FACES = [
+  '2',
+  '3',
+  '4',
+  '5',
+  '6',
+  '7',
+  '8',
+  '9',
+  '10',
+  'jack',
+  'queen',
+  'king',
+  'ace',
+];
+
+/**
+ * Possible short face values.
+ * [TODO] deduplicate faces/short faces, this is not DRY.
+ */
+const SUIT_FACES_SHORT = [
+  '2',
+  '3',
+  '4',
+  '5',
+  '6',
+  '7',
+  '8',
+  '9',
+  '10',
+  'J',
+  'Q',
+  'K',
+  'A',
+];
+
+/**
+ * Test `mapIndexToCardSuit`
+ * @param service Instance of the service to test against.
+ * @param suit Suit to test.
+ */
+function testMapIndexToCardSuit(service: PlayingCardsService, suit: 'spade' | 'heart' | 'club' | 'diamond') {
+  /**
+   * Starting index of suit range.
+   */
+  const index = DECK_SUITS[suit] * SUIT_SIZE;
+
+  /**
+   * Test against a range of concatenated playing card decks.
+   */
+  for (let i = 0; i < DECKS_TO_TEST; i++) {
+    const deckStart = DECK_SIZE * i;
+    const suitStart = index + deckStart;
+    const suitEnd = (index + 12) + deckStart;
+
+    /**
+     * Test suit start and end.
+     */
+    expect(service.mapIndexToCardSuit(suitStart)).toBe(suit);
+    expect(service.mapIndexToCardSuit(suitEnd)).toBe(suit);
+  }
+}
+
+/**
+ * Test `mapIndexToCardValue`
+ * @param service Instance of the service to test against.
+ * @param suit Suit to test.
+ */
+function testMapIndexToCardValue(service: PlayingCardsService, suit: 'spade' | 'heart' | 'club' | 'diamond') {
+  const suitStartIndex = DECK_SUITS[suit] * SUIT_SIZE;
+
+  for (let i = 0; i < DECKS_TO_TEST; i++) {
+    const deckStart = DECK_SIZE * i;
+
+    for (let j = 0; j < SUIT_SIZE; j++) {
+      const suitIndex = deckStart + suitStartIndex + j;
+      expect(service.mapIndexToCardValue(suitIndex)).toBe(SUIT_FACES[j]);
+    }
+  }
+}
+
+/**
+ * Test `mapIndexToCardValueShort`
+ * @param service Instance of the service to test against.
+ * @param suit Suit to test.
+ * [TODO] deduplicate faces/short faces, this is not DRY.
+ */
+function testMapIndexToCardValueShort(service: PlayingCardsService) {
+  for (let cardIndex = 0; cardIndex < (DECK_SIZE * DECKS_TO_TEST); cardIndex++) {
+    expect(service.mapIndexToCardValueShort(cardIndex)).toBe(SUIT_FACES_SHORT[cardIndex % SUIT_SIZE]);
+  }
+}
+
 describe('PlayingCardsService', () => {
   beforeEach(() => TestBed.configureTestingModule({}));
 
+  /**
+   * test: service smoke
+   */
   it('should be created', () => {
     const service: PlayingCardsService = TestBed.get(PlayingCardsService);
     expect(service).toBeTruthy();
   });
+
+  /**
+   * test: `mapIndexToCardSuit`
+   */
+  it('should correctly map spade card suits', () => {
+    const service: PlayingCardsService = TestBed.get(PlayingCardsService);
+    testMapIndexToCardSuit(service, 'spade');
+  });
+
+  it('should correctly map heart card suits', () => {
+    const service: PlayingCardsService = TestBed.get(PlayingCardsService);
+    testMapIndexToCardSuit(service, 'heart');
+  });
+
+  it('should correctly map club card suits', () => {
+    const service: PlayingCardsService = TestBed.get(PlayingCardsService);
+    testMapIndexToCardSuit(service, 'club');
+  });
+
+  it('should correctly map diamond card suits', () => {
+    const service: PlayingCardsService = TestBed.get(PlayingCardsService);
+    testMapIndexToCardSuit(service, 'diamond');
+  });
+
+  /**
+   * test: `mapIndexToCardValue`
+   */
+  it('should correctly map spade card faces', () => {
+    const service: PlayingCardsService = TestBed.get(PlayingCardsService);
+    testMapIndexToCardValue(service, 'spade');
+  });
+
+  it('should correctly map heart card faces', () => {
+    const service: PlayingCardsService = TestBed.get(PlayingCardsService);
+    testMapIndexToCardValue(service, 'heart');
+  });
+
+  it('should correctly map club card faces', () => {
+    const service: PlayingCardsService = TestBed.get(PlayingCardsService);
+    testMapIndexToCardValue(service, 'club');
+  });
+
+  it('should correctly map diamond card faces', () => {
+    const service: PlayingCardsService = TestBed.get(PlayingCardsService);
+    testMapIndexToCardValue(service, 'diamond');
+  });
+
+  /**
+   * test: `mapIndexToCardValueShort`
+   */
+  it('should correctly map short card faces', () => {
+    const service: PlayingCardsService = TestBed.get(PlayingCardsService);
+    testMapIndexToCardValueShort(service);
+  });
+
 });

--- a/src/app/playing-cards.service.spec.ts
+++ b/src/app/playing-cards.service.spec.ts
@@ -1,0 +1,12 @@
+import { TestBed } from '@angular/core/testing';
+
+import { PlayingCardsService } from './playing-cards.service';
+
+describe('PlayingCardsService', () => {
+  beforeEach(() => TestBed.configureTestingModule({}));
+
+  it('should be created', () => {
+    const service: PlayingCardsService = TestBed.get(PlayingCardsService);
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/playing-cards.service.ts
+++ b/src/app/playing-cards.service.ts
@@ -1,0 +1,141 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class PlayingCardsService {
+
+  constructor() { }
+
+  /**
+   * Translate a card's deck index to a suit.
+   * @param index Integer corresponding to a specific card in a collection of 1 or more standard playing card decks.
+   * [TODO] deduplicate face value and face value short functionality.
+   */
+  mapIndexToCardSuit(index: number) {
+    /**
+     * Normalize index if drawing from multiple decks.
+     * e.g. 2 decks will have 2 entire sets of Spades:
+     * 2 Aces of Spades, index 12 and 64
+     *   12 % 52 = 12
+     *   64 % 52 = 12
+     */
+    const normalizedIndex = index % 52;
+
+    if (normalizedIndex >= 0 && normalizedIndex < 13) {
+      return 'spade';
+    } else if (normalizedIndex >= 13 && normalizedIndex < 26) {
+      return 'heart';
+    } else if (normalizedIndex >= 26 && normalizedIndex < 39) {
+      return 'club';
+    } else {
+      return 'diamond';
+    }
+  }
+
+  /**
+   * Translate a card's deck index to a face value.
+   * @param index Integer corresponding to a specific card in a collection of 1 or more standard playing card decks.
+   */
+  mapIndexToCardValue(index: number) {
+
+    /**
+     * We don't need to normalize the index for card face value.
+     * Face values are always the same within suit boundaries.
+     * No matter how many decks we pull from, face value will always be index modulo 13.
+     */
+    const noSuit = index % 13;
+
+    let value;
+    if (noSuit >= 0 && noSuit < 9) {
+      /**
+       * Indices from 0 to 8 are just incremented by 2.
+       * Face values 2 through 10.
+       */
+      value = '' + (noSuit + 2);
+
+    } else {
+      /**
+       * Indices from 9 to 12 are face cards.
+       * Face values Jack through Ace.
+       */
+      switch (noSuit) {
+        case 9:
+          value = 'jack';
+          break;
+        case 10:
+          value = 'queen';
+          break;
+        case 11:
+          value = 'king';
+          break;
+        case 12:
+          value = 'ace';
+          break;
+
+        // This shouldn't ever happen.
+        default:
+          value = null;
+          break;
+      }
+
+    }
+
+    return value;
+  }
+
+  /**
+   * Map a card's face value to a 1 character symbol.
+   * @param index Index of card selected from 1 or more decks.
+   * [TODO] not happy with this repeated logic: calling another service member function,
+   * i.e. composing this new utility with result of mapIndexToCardValue and map of
+   * face value -> short symbol was causing problems in mat-slider.
+   *
+   * references to `this` here do not remain bound to the service context?
+   *
+   * maybe best to use same function and provide a flag to return "short" face value
+   *
+   * whatever, moving on; stop getting stuck on these details
+   */
+  mapIndexToCardValueShort(index: number | null): string {
+
+    if (index != null) {
+
+      /**
+       * Card face value label to return.
+       */
+      let label;
+
+      if (index < 9) {
+        /**
+         * Face values 2 through 10.
+         */
+        label = '' + (2 + index);
+
+      } else {
+        /**
+         * Face values, Jack through Ace (capitalized first letter).
+         */
+        switch (index) {
+          case 9:
+            label = 'J';
+            break;
+          case 10:
+            label = 'Q';
+            break;
+          case 11:
+            label = 'K';
+            break;
+          case 12:
+            label = 'A';
+            break;
+        }
+
+      }
+
+      return label;
+    }
+
+    return '';
+  }
+}

--- a/src/app/playing-cards.service.ts
+++ b/src/app/playing-cards.service.ts
@@ -101,22 +101,24 @@ export class PlayingCardsService {
 
     if (index != null) {
 
+      const noSuit = index % 13;
+
       /**
        * Card face value label to return.
        */
       let label;
 
-      if (index < 9) {
+      if (noSuit < 9) {
         /**
          * Face values 2 through 10.
          */
-        label = '' + (2 + index);
+        label = '' + (2 + noSuit);
 
       } else {
         /**
          * Face values, Jack through Ace (capitalized first letter).
          */
-        switch (index) {
+        switch (noSuit) {
           case 9:
             label = 'J';
             break;


### PR DESCRIPTION
move utilities to separate service for reuse
add service unit tests
fix card short face value mapping not handling multiple decks of cards because index wasn't normalized
fix draw hand not creating a new hand when filter options are unchanged (event provided to update filter options observable seems to be reused if no changes have been made to filter values so object reference was not being changed for input binding)